### PR TITLE
Dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -4982,6 +4983,33 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -13736,6 +13764,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 function Header() {
   const { isLoggedIn, logout } = useAuth();
@@ -8,7 +8,7 @@ function Header() {
 
   const handleLogout = () => {
     logout();
-    navigate('/login');
+    navigate("/login");
   };
 
   return (
@@ -17,8 +17,13 @@ function Header() {
         <nav style={styles.nav}>
           <h1 style={styles.title}>
             <span
-              style={{ ...styles.title, textDecoration: 'none', color: '#333', cursor: 'pointer' }}
-              onClick={() => navigate(isLoggedIn ? '/history' : '/login')}
+              style={{
+                ...styles.title,
+                textDecoration: "none",
+                color: "#333",
+                cursor: "pointer",
+              }}
+              onClick={() => navigate(isLoggedIn ? "/history" : "/login")}
             >
               자율 농작업 3D 경로 생성 지원 서비스
             </span>
@@ -26,13 +31,19 @@ function Header() {
           <div style={styles.links}>
             {isLoggedIn ? (
               <>
-                <Link to="/history" style={styles.link}>업로드 내역</Link>
-                <button onClick={handleLogout} style={styles.logoutButton}>로그아웃</button>
+                <Link to="/history" style={styles.link}>
+                  업로드 내역
+                </Link>
+                <button onClick={handleLogout} style={styles.logoutButton}>
+                  로그아웃
+                </button>
               </>
             ) : (
               <>
-                <span style={styles.guidanceText}>로그인 후 서비스 이용이 가능합니다</span>
-                <span onClick={() => navigate('/login')} style={styles.link}>로그인</span>
+                <span style={styles.guidanceText}>
+                  로그인 후 서비스 이용이 가능합니다
+                </span>
+                {/* <span onClick={() => navigate('/login')} style={styles.link}>로그인</span> */}
               </>
             )}
           </div>
@@ -44,61 +55,61 @@ function Header() {
 
 const styles = {
   header: {
-    padding: '1rem',
-    /*position: 'fixed', -> 상단바를 고정할지 안할지 결정*/ 
+    padding: "1rem",
+    /*position: 'fixed', -> 상단바를 고정할지 안할지 결정*/
     top: 0,
     left: 0,
     right: 0,
-    borderBottom: '1px solid #E2E8F0',
+    borderBottom: "1px solid #E2E8F0",
   },
   nav: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    maxWidth: '1200px',
-    margin: '0 auto'
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    maxWidth: "1200px",
+    margin: "0 auto",
   },
   title: {
     margin: 0,
-    fontSize: '1.5rem',
-    color: '#333'
+    fontSize: "1.5rem",
+    color: "#333",
   },
   links: {
-    display: 'flex',
-    gap: '2rem',
-    alignItems: 'center'
+    display: "flex",
+    gap: "2rem",
+    alignItems: "center",
   },
   link: {
-    color: '#000000',
-    fontWeight: '1000',
-    textDecoration: 'none',
-    cursor: 'pointer'
+    color: "#000000",
+    fontWeight: "1000",
+    textDecoration: "none",
+    cursor: "pointer",
   },
   logoutButton: {
-    background: 'none',
-    border: 'none',
-    color: '#000000',
-    fontWeight: '1000',
-    cursor: 'pointer',
+    background: "none",
+    border: "none",
+    color: "#000000",
+    fontWeight: "1000",
+    cursor: "pointer",
     padding: 0,
-    fontSize: 'inherit'
+    fontSize: "inherit",
   },
   guidanceText: {
-    color: '#666',
-    fontSize: '0.9rem',
-    fontWeight: '500'
+    color: "#666",
+    fontSize: "0.9rem",
+    fontWeight: "500",
   },
   loginButton: {
-    background: '#0B1C40',
-    color: '#fff',
-    border: 'none',
-    borderRadius: '4px',
-    padding: '0.4rem 1rem',
-    fontSize: '0.95rem',
-    fontWeight: '600',
-    cursor: 'pointer',
-    marginRight: '0.7rem'
-  }
+    background: "#0B1C40",
+    color: "#fff",
+    border: "none",
+    borderRadius: "4px",
+    padding: "0.4rem 1rem",
+    fontSize: "0.95rem",
+    fontWeight: "600",
+    cursor: "pointer",
+    marginRight: "0.7rem",
+  },
 };
 
-export default Header; 
+export default Header;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,0 +1,85 @@
+import React from "react";
+
+export default function Modal({ setIsModalOpen }) {
+  const handleClose = () => {
+    setIsModalOpen(false);
+  };
+  return (
+    <div style={styles.modal}>
+      <div style={styles.modalContent}>
+        <h2 style={styles.modalContentTitle}>개인정보 수집 및 이용 동의</h2>
+        <div>
+          <p style={styles.modalContentText}>
+            회사는 회원가입 및 서비스 제공을 위해 아래와 같이 개인정보를 수집 및
+            이용합니다.
+          </p>
+          <p style={styles.modalContentText}>
+            1. 수집 항목
+            <br />- 이메일(ID), 비밀번호, 이름, 전화번호
+          </p>
+          <p style={styles.modalContentText}>
+            2. 이용 목적
+            <br />- 회원가입 및 회원관리
+            <br />- 본인확인 및 서비스 이용에 따른 정보 제공
+          </p>
+          <p style={styles.modalContentText}>
+            3. 보유 및 이용 기간
+            <br />- 회원 탈퇴 시까지
+            <br />
+            (단, 관련 법령에 따라 일정 기간 보관이 필요한 경우 해당 기간까지)
+          </p>
+          <p style={styles.modalContentText}>
+            4. 동의 거부에 대한 안내
+            <br />- 위 개인정보 수집 및 이용에 대한 동의를 거부할 권리가
+            있습니다.
+            <br />- 다만, 필수 항목에 대한 동의를 거부할 경우 회원가입이 제한될
+            수 있습니다.
+          </p>
+        </div>
+        <button style={styles.modalContentButton} onClick={handleClose}>
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  modal: {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  modalContent: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    minWidth: "300px",
+    transform: "translate(-50%, -50%)",
+    backgroundColor: "white",
+    padding: "20px",
+    borderRadius: "10px",
+  },
+  modalContentTitle: {
+    fontSize: "22px",
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  modalContentText: {
+    fontSize: "14px",
+    marginBottom: "10px",
+  },
+  modalContentButton: {
+    width: "100%",
+    height: "40px",
+    backgroundColor: "#0B1C40",
+    color: "white",
+    border: "none",
+    borderRadius: "5px",
+    cursor: "pointer",
+    marginTop: "20px",
+  },
+};

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,35 +1,50 @@
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { PostLogin } from "../utils/api";
 
 function Login() {
   const navigate = useNavigate();
   const { login } = useAuth();
   const [formData, setFormData] = useState({
-    email: '',
-    password: ''
+    email: "",
+    password: "",
   });
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [name]: value
+      [name]: value,
     }));
   };
 
-  const handleSubmit = (e) => {
+  // 로그인 요청
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const tempEmail = process.env.REACT_APP_TEMP_EMAIL;
-    const tempPassword = process.env.REACT_APP_TEMP_PASSWORD;
-
-    if (formData.email === tempEmail && formData.password === tempPassword) {
-      login();
-      navigate('/history');
-      alert('로그인 성공!');
-    } else {
-      alert('이메일 또는 비밀번호가 일치하지 않습니다.');
+    try {
+      const response = await PostLogin(formData.email, formData.password);
+      console.log(response);
+      if (response.roles.includes("user")) {
+        login();
+        navigate("/history");
+        alert("로그인 성공!");
+      } else {
+        alert("이메일 또는 비밀번호가 일치하지 않습니다.");
+      }
+    } catch (err) {
+      console.error(err);
     }
+    // const tempEmail = process.env.REACT_APP_TEMP_EMAIL;
+    // const tempPassword = process.env.REACT_APP_TEMP_PASSWORD;
+
+    // if (formData.email === tempEmail && formData.password === tempPassword) {
+    //   login();
+    //   navigate("/history");
+    //   alert("로그인 성공!");
+    // } else {
+    //   alert("이메일 또는 비밀번호가 일치하지 않습니다.");
+    // }
   };
 
   return (
@@ -37,9 +52,9 @@ function Login() {
       <div style={styles.container}>
         <div style={styles.content}>
           <div style={styles.leftSection}>
-            <img 
-              src="/Mapgif.gif" 
-              alt="Map Animation" 
+            <img
+              src="/Mapgif.gif"
+              alt="Map Animation"
               style={styles.hdmapImage}
             />
           </div>
@@ -68,9 +83,13 @@ function Login() {
                 로그인
               </button>
               <div style={styles.links}>
-                <Link to="/signup" style={styles.link}>회원가입</Link>
+                <Link to="/signup" style={styles.link}>
+                  회원가입
+                </Link>
                 <span style={styles.divider}>|</span>
-                <Link to="/forgot-password" style={styles.link}>비밀번호 찾기</Link>
+                <Link to="/forgot-password" style={styles.link}>
+                  비밀번호 찾기
+                </Link>
               </div>
             </form>
           </div>
@@ -82,93 +101,93 @@ function Login() {
 
 const styles = {
   container: {
-    minHeight: 'calc(100vh - 200px)',
-    display: 'flex',
-    flexDirection: 'column',
-    padding: '200px 100px',
+    minHeight: "calc(100vh - 200px)",
+    display: "flex",
+    flexDirection: "column",
+    padding: "200px 100px",
   },
   content: {
     flex: 1,
-    display: 'flex',
-    maxWidth: '1200px',
-    margin: '0 auto',
-    padding: '2rem',
-    gap: '4rem',
-    backgroundColor: '#F3F8FB',
-    borderRadius: '12px',
-    boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+    display: "flex",
+    maxWidth: "1200px",
+    margin: "0 auto",
+    padding: "2rem",
+    gap: "4rem",
+    backgroundColor: "#F3F8FB",
+    borderRadius: "12px",
+    boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
   },
   leftSection: {
     flex: 1,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: '12px',
-    padding: '2rem',
-    overflow: 'hidden',
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "12px",
+    padding: "2rem",
+    overflow: "hidden",
   },
   hdmapImage: {
-    width: '100%',
-    height: 'auto',
-    objectFit: 'cover',
-    borderRadius: '8px',
+    width: "100%",
+    height: "auto",
+    objectFit: "cover",
+    borderRadius: "8px",
   },
   rightSection: {
     flex: 1,
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    padding: '2rem',
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    padding: "2rem",
   },
   title: {
-    fontSize: '1.5rem',
-    fontWeight: '600',
-    color: '#1E293B',
-    marginBottom: '2rem',
+    fontSize: "1.5rem",
+    fontWeight: "600",
+    color: "#1E293B",
+    marginBottom: "2rem",
   },
   form: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1rem',
-    width: '100%',
-    maxWidth: '400px',
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+    width: "100%",
+    maxWidth: "400px",
   },
   input: {
-    padding: '0.75rem',
-    borderRadius: '6px',
-    border: '1px solid #E2E8F0',
-    fontSize: '0.9rem',
-    outline: 'none',
-    transition: 'border-color 0.2s ease'
+    padding: "0.75rem",
+    borderRadius: "6px",
+    border: "1px solid #E2E8F0",
+    fontSize: "0.9rem",
+    outline: "none",
+    transition: "border-color 0.2s ease",
   },
   submitButton: {
-    backgroundColor: '#0B1C40',
-    color: '#ffffff',
-    padding: '0.75rem',
-    borderRadius: '6px',
-    border: 'none',
-    fontSize: '1rem',
-    fontWeight: '600',
-    cursor: 'pointer',
-    transition: 'background-color 0.2s ease',
-    marginTop: '1rem'
+    backgroundColor: "#0B1C40",
+    color: "#ffffff",
+    padding: "0.75rem",
+    borderRadius: "6px",
+    border: "none",
+    fontSize: "1rem",
+    fontWeight: "600",
+    cursor: "pointer",
+    transition: "background-color 0.2s ease",
+    marginTop: "1rem",
   },
   links: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: '1rem',
-    marginTop: '1rem',
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: "1rem",
+    marginTop: "1rem",
   },
   link: {
-    color: '#64748B',
-    textDecoration: 'none',
-    fontSize: '0.9rem',
-    transition: 'color 0.2s ease'
+    color: "#64748B",
+    textDecoration: "none",
+    fontSize: "0.9rem",
+    transition: "color 0.2s ease",
   },
   divider: {
-    color: '#E2E8F0',
+    color: "#E2E8F0",
   },
 };
 
-export default Login; 
+export default Login;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -33,7 +33,7 @@ function Login() {
         alert("이메일 또는 비밀번호가 일치하지 않습니다.");
       }
     } catch (err) {
-      console.error(err);
+      console.error("로그인 실패", err);
     }
     // const tempEmail = process.env.REACT_APP_TEMP_EMAIL;
     // const tempPassword = process.env.REACT_APP_TEMP_PASSWORD;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,6 +20,47 @@ api.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// 회원가입
+export const PostSignup = async (
+  username,
+  password,
+  fullName,
+  organization,
+  requireTerm
+) => {
+  //   try {
+  //     const response = await api.post("/api/users/users", {
+  //       user: {
+  //         username: username, // 이메일
+  //         password: password, // 비밀번호
+  //         fullName: fullName, // 이름
+  //         requireTerm: requireTerm, // 약관 동의 여부
+  //         status: 3, // 3: 회원가입 완료 & 미승인 상태
+  //       },
+  //       company: {
+  //         id: organization, // 소속
+  //       },
+  //     });
+  //     return response.data;
+  //   } catch (err) {
+  //     console.error(err);
+  //   }
+  return {
+    user: {
+      id: 1,
+      username: "test@example.com",
+      fullName: "테스트 사용자",
+      phone: "010-1234-5678",
+      requireTerm: true,
+      createdAt: "2025-06-27T10:25:00",
+      updatedAt: "2025-06-27T10:25:00",
+      lastLoginAt: null,
+      status: 0,
+    },
+  };
+};
+
+// 로그인
 export const PostLogin = async (email, password) => {
   //   const response = await api.post("/api/users/auth/tokens", {
   //     username: email,
@@ -30,6 +71,33 @@ export const PostLogin = async (email, password) => {
   return {
     token: "1234567890",
     tokenType: "Bearer",
-    roles: ["none"],
+    roles: ["user"],
   };
+};
+
+// 회사 목록 조회(회원가입 소속 선택 시 사용)
+export const GetCompanies = async () => {
+  // try {
+  //     const response = await api.get("/api/companies");
+  //     return response.data;
+  // } catch (err) {
+  //     console.error(err);
+  //     throw new Error("회사 목록을 불러오지 못했습니다.");
+  // }
+  return [
+    {
+      id: 1,
+      name: "테크 솔루션",
+      status: 1,
+      statusName: "활성",
+      createdAt: "2025-07-02T10:25:00",
+    },
+    {
+      id: 2,
+      name: "이노베이션 컴퍼니",
+      status: 1,
+      statusName: "활성",
+      createdAt: "2025-07-01T14:30:00",
+    },
+  ];
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.REACT_APP_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// 요청 인터셉터를 통해 매번 토큰을 동적으로 추가시킨다.
+api.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  // 두번째 인자 : 에러발생 시 처리
+  (error) => Promise.reject(error)
+);
+
+export const PostLogin = async (email, password) => {
+  //   const response = await api.post("/api/users/auth/tokens", {
+  //     username: email,
+  //     password: password,
+  //   });
+  //   return response.data;
+
+  return {
+    token: "1234567890",
+    tokenType: "Bearer",
+    roles: ["none"],
+  };
+};


### PR DESCRIPTION
## 🔍 개요
Api 요청 분리와 로그인 페이지 로직 연결

---

## 📌 작업 내용
- API 요청식 분리 작성 완료
- 로그인 요청 로직 작성 완료
- 회원가입 요청 로직 작성 완료
- 소속회사 입력 방식 문자입력 > 드롭다운 방식으로 변경
  - keti가 허가한 소속의 회사들만 보이도록 변경
- 개인 정보 동의 내용 확인 기능 추가 
  - 모달로 내용 확인 할 수 있도록 제작

---

## 🖼️ 스크린샷

![스크린샷 2025-07-07 174403](https://github.com/user-attachments/assets/30ccfc94-9f68-4c0e-bcd1-77459598d5fb)

![스크린샷 2025-07-07 174413](https://github.com/user-attachments/assets/0539642b-946b-4fa8-b5af-e2be8674b7ce)

![스크린샷 2025-07-07 174418](https://github.com/user-attachments/assets/c2f6a839-f9a1-415d-a462-b73a256bec7c)

---

## 🐞 에러 리포트 / 기술적 이슈
- 인수인계 받은 인라인 스타일의 CSS 양식에서는 Hover 이벤트 작성이 어려운 점을 확인
- 현재 백엔드와의 연결 부재로 api 요청 양식은 작성 후 주석 처리 >> 응답 객체만 직접 제작하여 반환시켜 진행

---

## 📘 배운 점
- 클래스를 활용하거나 Styled-components를 활용해야지 여러 이벤트 적용이 수월하다는것을 배움
- 백엔드와의 원활한 개발을 위해 API 명세를 확인하며 개발을 진행

---

## 📎 참고 사항
- 현재 CSS 스타일링 방식과 자연스럽게 연결지으려면 Styled-Components 방식도 고려

---

## ⏭️ 다음 예정 업무
- 비밀번호 찾기 API 로직 작성 및 이메일로 오는 비밀번호 재설정 페이지의 라우팅 설계 예정